### PR TITLE
Add trading bot scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+ai-trading-bot/.env
+ai-trading-bot/logs/
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# AI_Trading
+# AI Trading
+
+This repository contains an experimental crypto trading bot implemented in Node.js. The `ai-trading-bot` folder provides a basic scaffolding with placeholder logic for price feeds, technical indicators, strategy, risk management and a small dashboard.
+
+The project uses `ethers` to interact with Ethereum mainnet and `technicalindicators` for trading signals. Environment variables such as your Infura key and wallet private key should be placed in `ai-trading-bot/.env` (excluded from version control).

--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -1,0 +1,39 @@
+require('dotenv').config();
+const { getPrice } = require('./datafeeds');
+const strategy = require('./strategy');
+const trade = require('./trade');
+const risk = require('./risk');
+const fs = require('fs');
+const config = require('./config');
+
+let history = [];
+let paper = true; // default to paper trading
+
+async function loop() {
+  for (const symbol of config.TOKENS) {
+    const price = await getPrice(symbol);
+    if (!price) continue;
+    history.push({ time: Date.now(), close: price });
+    if (history.length > 100) history.shift();
+    const score = strategy.scoreSignals(history);
+    if (strategy.shouldBuy(score) && !paper) {
+      await trade.buy(0.01, []); // placeholder path
+      risk.updateEntry(price);
+      logTrade('BUY', symbol, 0.01, price);
+    }
+    if (risk.stopLoss(price) || risk.takeProfit(price)) {
+      if (!paper) {
+        await trade.sell(0.01, []); // placeholder path
+      }
+      logTrade('SELL', symbol, 0.01, price);
+    }
+  }
+}
+
+function logTrade(side, token, amount, price) {
+  const trades = JSON.parse(fs.readFileSync('./logs/trades.json'));
+  trades.push({ time: new Date().toISOString(), side, token, amount, price });
+  fs.writeFileSync('./logs/trades.json', JSON.stringify(trades, null, 2));
+}
+
+setInterval(loop, 60 * 1000);

--- a/ai-trading-bot/config.js
+++ b/ai-trading-bot/config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  SLIPPAGE: 0.005, // 0.5%
+  TOKENS: ['ETH', 'MATIC', 'LINK', 'UNI', 'ARB'],
+  RSI_PERIOD: 14,
+  MACD_FAST: 12,
+  MACD_SLOW: 26,
+  MACD_SIGNAL: 9,
+  BOLLINGER_PERIOD: 20,
+  STOP_LOSS: 0.05, // 5%
+  TAKE_PROFIT: 0.1  // 10%
+};

--- a/ai-trading-bot/dashboard/dashboard.js
+++ b/ai-trading-bot/dashboard/dashboard.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const res = await fetch('../logs/trades.json');
+  const trades = await res.json();
+  const container = document.getElementById('trades');
+  container.innerHTML = trades.map(t => `<div>${t.time}: ${t.side} ${t.amount} ${t.token} @ ${t.price}</div>`).join('');
+});

--- a/ai-trading-bot/dashboard/index.html
+++ b/ai-trading-bot/dashboard/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Trading Bot Dashboard</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>AI Trading Bot Dashboard</h1>
+  <div id="pnl">PnL: 0</div>
+  <div id="trades"></div>
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/ai-trading-bot/dashboard/style.css
+++ b/ai-trading-bot/dashboard/style.css
@@ -1,0 +1,4 @@
+body { font-family: Arial, sans-serif; background: #111; color: #eee; }
+h1 { text-align: center; }
+#pnl { margin: 20px; font-size: 1.2em; }
+#trades { margin: 20px; }

--- a/ai-trading-bot/datafeeds.js
+++ b/ai-trading-bot/datafeeds.js
@@ -1,0 +1,14 @@
+const axios = require('axios');
+
+async function getPrice(symbol) {
+  try {
+    const url = `https://api.coingecko.com/api/v3/simple/price?ids=${symbol.toLowerCase()}&vs_currencies=usd`;
+    const { data } = await axios.get(url);
+    return data[symbol.toLowerCase()].usd;
+  } catch (err) {
+    console.error('Price fetch error', err.message);
+    return null;
+  }
+}
+
+module.exports = { getPrice };

--- a/ai-trading-bot/indicators.js
+++ b/ai-trading-bot/indicators.js
@@ -1,0 +1,22 @@
+const ti = require('technicalindicators');
+
+function rsi(values, period) {
+  return ti.RSI.calculate({ values, period });
+}
+
+function macd(values) {
+  return ti.MACD.calculate({
+    values,
+    fastPeriod: 12,
+    slowPeriod: 26,
+    signalPeriod: 9,
+    SimpleMAOscillator: false,
+    SimpleMASignal: false
+  });
+}
+
+function bollinger(values, period) {
+  return ti.BollingerBands.calculate({ period, values, stdDev: 2 });
+}
+
+module.exports = { rsi, macd, bollinger };

--- a/ai-trading-bot/package.json
+++ b/ai-trading-bot/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ai-trading-bot",
+  "version": "1.0.0",
+  "description": "Aggressive crypto trading bot using Uniswap V2",
+  "main": "bot.js",
+  "scripts": {
+    "start": "node bot.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "dotenv": "^16.5.1",
+    "ethers": "^6.8.1",
+    "express": "^4.19.2",
+    "technicalindicators": "^3.1.0"
+  }
+}

--- a/ai-trading-bot/risk.js
+++ b/ai-trading-bot/risk.js
@@ -1,0 +1,17 @@
+let entryPrice = null;
+
+function updateEntry(price) {
+  entryPrice = price;
+}
+
+function stopLoss(price) {
+  if (entryPrice && price < entryPrice * (1 - 0.05)) return true;
+  return false;
+}
+
+function takeProfit(price) {
+  if (entryPrice && price > entryPrice * (1 + 0.1)) return true;
+  return false;
+}
+
+module.exports = { updateEntry, stopLoss, takeProfit };

--- a/ai-trading-bot/strategy.js
+++ b/ai-trading-bot/strategy.js
@@ -1,0 +1,27 @@
+const indicators = require('./indicators');
+const config = require('./config');
+
+function scoreSignals(history) {
+  const closing = history.map(c => c.close);
+  const rsiValues = indicators.rsi(closing, config.RSI_PERIOD).slice(-1)[0];
+  const macdValues = indicators.macd(closing).slice(-1)[0];
+  const boll = indicators.bollinger(closing, config.BOLLINGER_PERIOD).slice(-1)[0];
+  let score = 0;
+  if (rsiValues < 30) score += 1; // oversold
+  if (rsiValues > 70) score -= 1; // overbought
+  if (macdValues && macdValues.MACD > macdValues.signal) score += 1;
+  if (macdValues && macdValues.MACD < macdValues.signal) score -= 1;
+  if (boll && closing[closing.length - 1] < boll.lower) score += 1;
+  if (boll && closing[closing.length - 1] > boll.upper) score -= 1;
+  return score;
+}
+
+function shouldBuy(score) {
+  return score > 1;
+}
+
+function shouldSell(score) {
+  return score < -1;
+}
+
+module.exports = { scoreSignals, shouldBuy, shouldSell };

--- a/ai-trading-bot/trade.js
+++ b/ai-trading-bot/trade.js
@@ -1,0 +1,36 @@
+const { ethers } = require('ethers');
+const config = require('./config');
+require('dotenv').config();
+
+const routerAbi = [
+  'function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline) payable returns (uint[] memory amounts)',
+  'function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline) returns (uint[] memory amounts)'
+];
+
+const provider = new ethers.InfuraProvider('mainnet', process.env.INFURA_API_KEY);
+const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
+const router = new ethers.Contract('0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f', routerAbi, wallet); // placeholder address
+
+async function buy(amountEth, path) {
+  const tx = await router.swapExactETHForTokens(
+    0,
+    path,
+    wallet.address,
+    Math.floor(Date.now() / 1000) + 60 * 10,
+    { value: ethers.parseEther(amountEth.toString()) }
+  );
+  return tx.wait();
+}
+
+async function sell(amountToken, path) {
+  const tx = await router.swapExactTokensForETH(
+    ethers.parseUnits(amountToken.toString(), 18),
+    0,
+    path,
+    wallet.address,
+    Math.floor(Date.now() / 1000) + 60 * 10
+  );
+  return tx.wait();
+}
+
+module.exports = { buy, sell };


### PR DESCRIPTION
## Summary
- scaffold `ai-trading-bot` folder with starter Node.js files
- add gitignore and update README

## Testing
- `npm install` *(fails: 403 Forbidden, registry access blocked)*
- `npm test` *(fails: missing test script)*

------
https://chatgpt.com/codex/tasks/task_e_6853ac15236883328c6b56fd09ef8b4b