### PR TITLE
Implement indicator-driven trading strategy

### DIFF
--- a/ai-trading-bot/strategy.js
+++ b/ai-trading-bot/strategy.js
@@ -1,27 +1,60 @@
-const indicators = require('./indicators');
-const config = require('./config');
+const ti = require('technicalindicators');
 
-function scoreSignals(history) {
-  const closing = history.map(c => c.close);
-  const rsiValues = indicators.rsi(closing, config.RSI_PERIOD).slice(-1)[0];
-  const macdValues = indicators.macd(closing).slice(-1)[0];
-  const boll = indicators.bollinger(closing, config.BOLLINGER_PERIOD).slice(-1)[0];
-  let score = 0;
-  if (rsiValues < 30) score += 1; // oversold
-  if (rsiValues > 70) score -= 1; // overbought
-  if (macdValues && macdValues.MACD > macdValues.signal) score += 1;
-  if (macdValues && macdValues.MACD < macdValues.signal) score -= 1;
-  if (boll && closing[closing.length - 1] < boll.lower) score += 1;
-  if (boll && closing[closing.length - 1] > boll.upper) score -= 1;
-  return score;
+// Analyze price history and return trade signal information
+// symbol - string like "ETH"
+// prices - array of closing prices (oldest to newest)
+function analyze(symbol, prices) {
+  if (!Array.isArray(prices) || prices.length < 30) {
+    console.error('Not enough price data provided to strategy');
+    return null;
+  }
+
+  // calculate indicators
+  const rsi = ti.RSI.calculate({ values: prices, period: 14 }).slice(-1)[0];
+  const macd = ti.MACD.calculate({
+    values: prices,
+    fastPeriod: 12,
+    slowPeriod: 26,
+    signalPeriod: 9,
+    SimpleMAOscillator: false,
+    SimpleMASignal: false
+  }).slice(-1)[0];
+
+  const boll = ti.BollingerBands.calculate({
+    period: 20,
+    values: prices,
+    stdDev: 2
+  }).slice(-1)[0];
+
+  const close = prices[prices.length - 1];
+  const histogram = macd ? macd.histogram : undefined;
+
+  let bbPosition = 'inside';
+  if (boll) {
+    if (close > boll.upper) bbPosition = 'above';
+    else if (close < boll.lower) bbPosition = 'below';
+  }
+
+  console.log(`\ud83d\udcc8 ${symbol} \u2192 RSI: ${rsi?.toFixed(1)}, MACD: ${histogram?.toFixed(4)}, Bollinger: ${bbPosition}`);
+
+  if (rsi !== undefined && histogram !== undefined && boll) {
+    if (rsi < 30 && histogram > 0 && close < boll.lower) {
+      return {
+        action: 'BUY',
+        confidence: 8,
+        reason: 'RSI<30, BB below, MACD turning up'
+      };
+    }
+    if (rsi > 70 && histogram < 0 && close > boll.upper) {
+      return {
+        action: 'SELL',
+        confidence: 8,
+        reason: 'RSI>70, BB above, MACD turning down'
+      };
+    }
+  }
+
+  return null;
 }
 
-function shouldBuy(score) {
-  return score > 1;
-}
-
-function shouldSell(score) {
-  return score < -1;
-}
-
-module.exports = { scoreSignals, shouldBuy, shouldSell };
+module.exports = { analyze };


### PR DESCRIPTION
## Summary
- implement a full indicator-based trading strategy using RSI, MACD and Bollinger Bands
- update bot logic to call the new `analyze` function

## Testing
- `npm --prefix ai-trading-bot test` *(fails: Missing script & network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6853b3666b508332867578fd51a61990