### PR TITLE
Enable live trade updates in dashboard

### DIFF
--- a/ai-trading-bot/dashboard/dashboard.js
+++ b/ai-trading-bot/dashboard/dashboard.js
@@ -1,6 +1,18 @@
-document.addEventListener('DOMContentLoaded', async () => {
-  const res = await fetch('../logs/trades.json');
-  const trades = await res.json();
-  const container = document.getElementById('trades');
-  container.innerHTML = trades.map(t => `<div>${t.time}: ${t.side} ${t.amount} ${t.token} @ ${t.price}</div>`).join('');
+async function loadTrades() {
+  try {
+    const res = await fetch('../logs/trades.json');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const trades = await res.json();
+    const container = document.getElementById('trades');
+    container.innerHTML = trades
+      .map(t => `<div>${t.time}: ${t.side} ${t.amount} ${t.token} @ ${t.price}</div>`)
+      .join('');
+  } catch (err) {
+    console.error('Failed to load trades:', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadTrades();
+  setInterval(loadTrades, 5000);
 });

--- a/ai-trading-bot/dashboard/index.html
+++ b/ai-trading-bot/dashboard/index.html
@@ -8,6 +8,7 @@
 <body>
   <h1>AI Trading Bot Dashboard</h1>
   <div id="pnl">PnL: 0</div>
+  <h2>Trade History</h2>
   <div id="trades"></div>
   <script src="dashboard.js"></script>
 </body>

--- a/ai-trading-bot/dashboard/style.css
+++ b/ai-trading-bot/dashboard/style.css
@@ -2,3 +2,4 @@ body { font-family: Arial, sans-serif; background: #111; color: #eee; }
 h1 { text-align: center; }
 #pnl { margin: 20px; font-size: 1.2em; }
 #trades { margin: 20px; }
+#trades div { margin-bottom: 5px; }


### PR DESCRIPTION
## Summary
- render trade history on initial page load and refresh every 5 seconds
- add simple trade history heading and style

## Testing
- `node -c ai-trading-bot/dashboard/dashboard.js`

------
https://chatgpt.com/codex/tasks/task_e_685614ae320c8332a9f301d53f113566