### PR TITLE
Expand token list to 25 coins

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -28,7 +28,7 @@ async function loop() {
   const prices = await getPrices();
   if (!prices) return;
 
-  for (const symbol of config.TOKENS) {
+  for (const symbol of config.coins) {
     const price = prices[symbol.toLowerCase()];
     if (!price) continue;
     console.log(`\u23f1 Checking ${symbol} at $${price}`);

--- a/ai-trading-bot/config.js
+++ b/ai-trading-bot/config.js
@@ -1,6 +1,32 @@
 module.exports = {
   SLIPPAGE: 0.005, // 0.5%
-  TOKENS: ['ETH', 'MATIC', 'LINK', 'UNI', 'ARB'],
+  coins: [
+    'ETH',      // Ethereum
+    'LINK',     // Chainlink
+    'UNI',      // Uniswap
+    'ARB',      // Arbitrum
+    'MATIC',    // Polygon
+    'WBTC',     // Wrapped Bitcoin
+    'AAVE',     // Aave
+    'COMP',     // Compound
+    'SNX',      // Synthetix
+    'SUSHI',    // SushiSwap
+    'LDO',      // Lido DAO
+    'MKR',      // Maker
+    'CRV',      // Curve DAO
+    'GRT',      // The Graph
+    'ENS',      // Ethereum Name Service
+    '1INCH',    // 1inch
+    'DYDX',     // dYdX
+    'BAL',      // Balancer
+    'BNT',      // Bancor
+    'REN',      // Ren Protocol
+    'OCEAN',    // Ocean Protocol
+    'BAND',     // Band Protocol
+    'RLC',      // iExec RLC
+    'AMPL',     // Ampleforth
+    'STORJ'     // Storj
+  ],
   RSI_PERIOD: 14,
   MACD_FAST: 12,
   MACD_SLOW: 26,

--- a/ai-trading-bot/datafeeds.js
+++ b/ai-trading-bot/datafeeds.js
@@ -1,22 +1,48 @@
 const axios = require('axios');
 
+// Mapping from token symbol to CoinGecko id
+const ID_MAP = {
+  ETH: 'ethereum',
+  LINK: 'chainlink',
+  UNI: 'uniswap',
+  ARB: 'arbitrum',
+  MATIC: 'matic-network',
+  WBTC: 'wrapped-bitcoin',
+  AAVE: 'aave',
+  COMP: 'compound-governance-token',
+  SNX: 'synthetix-network-token',
+  SUSHI: 'sushi',
+  LDO: 'lido-dao',
+  MKR: 'maker',
+  CRV: 'curve-dao-token',
+  GRT: 'the-graph',
+  ENS: 'ethereum-name-service',
+  '1INCH': '1inch',
+  DYDX: 'dydx',
+  BAL: 'balancer',
+  BNT: 'bancor',
+  REN: 'republic-protocol',
+  OCEAN: 'ocean-protocol',
+  BAND: 'band-protocol',
+  RLC: 'iexec-rlc',
+  AMPL: 'ampleforth',
+  STORJ: 'storj'
+};
+
 async function getPrices() {
   console.log("\ud83d\udce1 Fetching prices from CoinGecko...");
   try {
-    const res = await axios.get("https://api.coingecko.com/api/v3/simple/price", {
-      params: {
-        ids: "ethereum,polygon,chainlink,uniswap,arbitrum",
-        vs_currencies: "usd"
-      }
-    });
+    const ids = Object.values(ID_MAP).join(',');
+    const res = await axios.get(
+      "https://api.coingecko.com/api/v3/simple/price",
+      { params: { ids, vs_currencies: "usd" } }
+    );
     console.log("\u2705 Price data:", res.data);
-    return {
-      eth: res.data.ethereum?.usd,
-      matic: res.data.polygon?.usd,
-      link: res.data.chainlink?.usd,
-      uni: res.data.uniswap?.usd,
-      arb: res.data.arbitrum?.usd
-    };
+    const prices = {};
+    for (const [symbol, id] of Object.entries(ID_MAP)) {
+      prices[symbol.toLowerCase()] = res.data[id]?.usd;
+    }
+    return prices;
   } catch (err) {
     console.error("\u274c Price fetch error:", err.message);
     return null;


### PR DESCRIPTION
## Summary
- broaden trading configuration with 25 ERC-20 tokens
- update bot to iterate over new coin list
- fetch prices for all coins from CoinGecko

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68564f68d3388332b51ad28daacbb6ce