### PR TITLE
Make paper trading configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository contains an experimental crypto trading bot implemented in Node.js. The `ai-trading-bot` folder provides a basic scaffolding with placeholder logic for price feeds, technical indicators, strategy, risk management and a small dashboard.
 
-The project uses `ethers` to interact with Ethereum mainnet and `technicalindicators` for trading signals. Copy `ai-trading-bot/.env.example` to `ai-trading-bot/.env` and fill in your Infura key and wallet private key. The `.env` file is excluded from version control so your credentials remain private.
+The project uses `ethers` to interact with Ethereum mainnet and `technicalindicators` for trading signals. Copy `ai-trading-bot/.env.example` to `ai-trading-bot/.env` and fill in your Infura key and wallet private key. Set `PAPER=true` in the `.env` file to run in paper trading mode or `false` to place real trades. The `.env` file is excluded from version control so your credentials remain private.

--- a/ai-trading-bot/.env.example
+++ b/ai-trading-bot/.env.example
@@ -2,3 +2,4 @@
 # Copy this file to .env and fill in your own credentials
 INFURA_API_KEY=your_infura_api_key_here
 PRIVATE_KEY=your_ethereum_private_key_here
+PAPER=true

--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -9,7 +9,7 @@ const config = require('./config');
 
 // Maintain an in-memory price history for each token
 const history = {};
-let paper = true; // default to paper trading
+let paper = process.env.PAPER === 'true'; // default to paper trading
 let activeTrades = {};
 
 const logFile = path.join(__dirname, '..', 'data', 'trade-log.json');


### PR DESCRIPTION
## Summary
- allow enabling/disabling paper trading using the `PAPER` env variable
- document the new environment variable in `README` and `.env.example`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685660a16ba88332ab1495f939167d76