### PR TITLE
Add liquidity check before swaps

### DIFF
--- a/ai-trading-bot/config.js
+++ b/ai-trading-bot/config.js
@@ -20,7 +20,6 @@ module.exports = {
     'DYDX',     // dYdX
     'BAL',      // Balancer
     'BNT',      // Bancor
-    'REN',      // Ren Protocol
     'OCEAN',    // Ocean Protocol
     'BAND',     // Band Protocol
     'RLC',      // iExec RLC

--- a/ai-trading-bot/datafeeds.js
+++ b/ai-trading-bot/datafeeds.js
@@ -21,7 +21,6 @@ const ID_MAP = {
   DYDX: 'dydx',
   BAL: 'balancer',
   BNT: 'bancor',
-  REN: 'republic-protocol',
   OCEAN: 'ocean-protocol',
   BAND: 'band-protocol',
   RLC: 'iexec-rlc',

--- a/ai-trading-bot/trade.js
+++ b/ai-trading-bot/trade.js
@@ -6,12 +6,39 @@ require('dotenv').config();
 
 const routerAbi = [
   'function swapExactETHForTokens(uint amountOutMin, address[] calldata path, address to, uint deadline) payable returns (uint[] memory amounts)',
-  'function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline) returns (uint[] memory amounts)'
+  'function swapExactTokensForETH(uint amountIn, uint amountOutMin, address[] calldata path, address to, uint deadline) returns (uint[] memory amounts)',
+  'function getAmountsOut(uint amountIn, address[] calldata path) external view returns (uint[] memory amounts)'
 ];
 
 const provider = new ethers.InfuraProvider('mainnet', process.env.INFURA_API_KEY);
 const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
-const router = new ethers.Contract('0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f', routerAbi, wallet); // placeholder address
+// Uniswap V2 Router
+const router = new ethers.Contract('0x7a250d5630B4cF539739df2C5dAcb4c659F2488D', routerAbi, wallet);
+
+const WETH_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const TOKEN_ADDRESS_MAP = {
+  LINK: '0x514910771AF9Ca656af840dff83E8264EcF986CA',
+  UNI: '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
+  MATIC: '0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0',
+  WBTC: '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599',
+  AAVE: '0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9',
+  COMP: '0xc00e94Cb662C3520282E6f5717214004A7f26888',
+  SNX: '0xC011A72400E58ecD99Ee497CF89E3775d4bd732F',
+  SUSHI: '0x6B3595068778dd592e39A122f4f5a5CF09C90fE2',
+  LDO: '0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32',
+  MKR: '0x9f8F72aa9304c8B593d555F12eF6589Cc3A579A2',
+  CRV: '0xD533a949740bb3306d119CC777fa900bA034cd52',
+  GRT: '0xc944E90C64B2c07662A292be6244BDf05Cda44a7',
+  '1INCH': '0x111111111117dC0aa78b770fA6A738034120C302',
+  DYDX: '0x92D6C1e31e14520e676a687F0a93788B716BEff5',
+  BAL: '0xba100000625a3754423978a60c9317c58a424e3D',
+  BNT: '0x1f573d6fb3f13d689ff844b4c6deebd4994e9e6f',
+  OCEAN: '0x967da4048cd07ab37855c090aaf366e4ce1b9f48',
+  BAND: '0xba11d479a30a3DbA9281e1D8E6cE942Ca109b3A6',
+  RLC: '0x607F4C5BB672230e8672085532f7e901544a7375',
+  AMPL: '0xd46ba6D942050d489DBd938a2c3d573929F443ac',
+  STORJ: '0xb64ef51c888972c908cfacf59b47c1afbc0ab8ac'
+};
 
 const errorLogPath = path.join(__dirname, '..', 'logs', 'error.log');
 
@@ -46,16 +73,37 @@ async function gasOkay() {
   return true;
 }
 
+async function hasLiquidity(amountEth, token) {
+  const tokenAddr = TOKEN_ADDRESS_MAP[token.toUpperCase()];
+  if (!tokenAddr) return false;
+  try {
+    const amounts = await router.getAmountsOut(
+      ethers.parseEther(amountEth.toString()),
+      [WETH_ADDRESS, tokenAddr]
+    );
+    return amounts && amounts[1] && amounts[1] > 0n;
+  } catch {
+    return false;
+  }
+}
+
 async function buy(amountEth, path, token) {
   if (token && ['ETH', 'WETH'].includes(token.toUpperCase())) {
     console.log('\u26a0\ufe0f Skipping ETH to ETH trade');
     return null;
   }
   if (!await gasOkay()) return null;
+  const tokenAddr = TOKEN_ADDRESS_MAP[token.toUpperCase()];
+  const swapPath = [WETH_ADDRESS, tokenAddr];
+  if (!await hasLiquidity(amountEth, token)) {
+    console.log(`Insufficient liquidity for ETH\u2192${token}`);
+    appendLog({ time: new Date().toISOString(), action: 'SKIP', token, reason: 'liquidity' });
+    return null;
+  }
   try {
     const tx = await router.swapExactETHForTokens(
       0,
-      path,
+      swapPath,
       wallet.address,
       Math.floor(Date.now() / 1000) + 60 * 10,
       { value: ethers.parseEther(amountEth.toString()) }
@@ -75,11 +123,13 @@ async function sell(amountToken, path, token) {
     return null;
   }
   if (!await gasOkay()) return null;
+  const tokenAddr = TOKEN_ADDRESS_MAP[token.toUpperCase()];
+  const swapPath = [tokenAddr, WETH_ADDRESS];
   try {
     const tx = await router.swapExactTokensForETH(
       ethers.parseUnits(amountToken.toString(), 18),
       0,
-      path,
+      swapPath,
       wallet.address,
       Math.floor(Date.now() / 1000) + 60 * 10
     );


### PR DESCRIPTION
## Summary
- fix router address and include `getAmountsOut`
- check Uniswap liquidity before swapping
- skip tokens with low/no liquidity
- remove problematic REN token from config and datafeeds

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68573f8290d4833296875c1b5db1cafa