### PR TITLE
Improve trading bot log formatting

### DIFF
--- a/ai-trading-bot/config.js
+++ b/ai-trading-bot/config.js
@@ -35,5 +35,6 @@ module.exports = {
   TAKE_PROFIT: 0.08, // 8%
   TRAILING_STOP: 0.02,
   GAS_LIMIT_GWEI: 80,
-  TRADE_ALLOCATION: 0.22
+  TRADE_ALLOCATION: 0.22,
+  prettyLogs: true
 };


### PR DESCRIPTION
## Summary
- add `prettyLogs` toggle to config
- format scanned coin logs as clean table
- show top 5 coins in a table
- highlight buy/sell signals with detailed message

## Testing
- `node --check ai-trading-bot/bot.js`
- `node --check ai-trading-bot/config.js`

------
https://chatgpt.com/codex/tasks/task_e_68574a989cc88332a88edbef94532a27