### PR TITLE
Clean console output

### DIFF
--- a/ai-trading-bot/datafeeds.js
+++ b/ai-trading-bot/datafeeds.js
@@ -29,14 +29,12 @@ const ID_MAP = {
 };
 
 async function getPrices() {
-  console.log("\ud83d\udce1 Fetching prices from CoinGecko...");
   try {
     const ids = Object.values(ID_MAP).join(',');
     const res = await axios.get(
       "https://api.coingecko.com/api/v3/simple/price",
       { params: { ids, vs_currencies: "usd" } }
     );
-    console.log("\u2705 Price data:", res.data);
     const prices = {};
     for (const [symbol, id] of Object.entries(ID_MAP)) {
       prices[symbol.toLowerCase()] = res.data[id]?.usd;

--- a/ai-trading-bot/strategy.js
+++ b/ai-trading-bot/strategy.js
@@ -67,8 +67,7 @@ function analyze(symbol, prices) {
 
   const aggressive = process.env.AGGRESSIVE === 'true';
 
-  // Log all signals for transparency
-  console.log(`${symbol} trade check:`, signals);
+  // Previously logged signals for debugging; removed for cleaner output
 
   if ((aggressive && signals.length >= 2) || signals.length >= 3) {
     return { action: 'BUY', confidence: signals.length, reasons: signals };

--- a/ai-trading-bot/trade.js
+++ b/ai-trading-bot/trade.js
@@ -74,7 +74,6 @@ async function gasOkay() {
   const gasPrice = feeData.gasPrice || ethers.parseUnits('0', 'gwei');
   if (gasPrice > ethers.parseUnits(config.GAS_LIMIT_GWEI.toString(), 'gwei')) {
     const gwei = Number(ethers.formatUnits(gasPrice, 'gwei')).toFixed(1);
-    console.log(`\u26FD Gas ${gwei} gwei exceeds limit`);
     logError(`Gas price ${gwei} gwei exceeds limit`);
     appendLog({ time: new Date().toISOString(), action: 'SKIP', reason: 'Gas high', gas: gwei });
     return false;
@@ -98,14 +97,12 @@ async function hasLiquidity(amountEth, token) {
 
 async function buy(amountEth, path, token) {
   if (token && ['ETH', 'WETH'].includes(token.toUpperCase())) {
-    console.log('\u26a0\ufe0f Skipping ETH to ETH trade');
     return null;
   }
   if (!await gasOkay()) return null;
   const tokenAddr = TOKEN_ADDRESS_MAP[token.toUpperCase()];
   const swapPath = [WETH_ADDRESS, tokenAddr];
   if (!await hasLiquidity(amountEth, token)) {
-    console.log(`Insufficient liquidity for ETH\u2192${token}`);
     appendLog({ time: new Date().toISOString(), action: 'SKIP', token, reason: 'liquidity' });
     return null;
   }
@@ -128,7 +125,6 @@ async function buy(amountEth, path, token) {
 
 async function sell(amountToken, path, token) {
   if (token && ['ETH', 'WETH'].includes(token.toUpperCase())) {
-    console.log('\u26a0\ufe0f Skipping ETH to ETH trade');
     return null;
   }
   if (!await gasOkay()) return null;


### PR DESCRIPTION
## Summary
- remove verbose scan logging and background info
- always print the summary table each cycle
- group buy and sell messages with color headers
- drop debug logs from datafeeds, trade helpers, and strategy

## Testing
- `node -c ai-trading-bot/bot.js`
- `node -c ai-trading-bot/datafeeds.js`
- `node -c ai-trading-bot/strategy.js`
- `node -c ai-trading-bot/trade.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6857616cf1d4833297642aa894cc9f0d