### PR TITLE
Add scan header for top coin scan

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -143,9 +143,11 @@ function renderSummary(list) {
 
 async function evaluate(prices) {
   const res = [];
+  const totalScans = config.coins.length;
   for (const [index, symbol] of config.coins.entries()) {
     const ts = new Date().toISOString().replace('T', ' ').slice(0, 19);
-    console.log(`[${ts}] Scanning ${index + 1}/${config.coins.length}: ${symbol}`);
+    console.log(`[${ts}] [Scan ${index + 1}/${totalScans}] === ♦ TOP 5 COINS (Highest Scores) ===`);
+    console.log(`[${ts}] Scanning ${index + 1}/${totalScans}: ${symbol}`);
     const price = prices[symbol.toLowerCase()];
     if (!price) continue;
     if (!history[symbol]) history[symbol] = [];


### PR DESCRIPTION
## Summary
- show scan count header before each coin scan in `bot.js`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6857725fd7b08332807ab793dc8a6f8d