### PR TITLE
Fix trade sizing with score-based allocation

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -189,15 +189,9 @@ async function checkTrades(entries, ethPrice) {
         const gasCost = Number(ethers.formatEther(gasPrice * 210000n));
         const available = Math.max(balance - gasCost, 0);
 
-        const capitalUsd = available * ethPrice;
-        const usdAmount = risk.calculatePositionSize(score, capitalUsd);
-        if (usdAmount < MIN_TRADE_USD) {
-          console.log(`Skipping ${symbol} — below $${MIN_TRADE_USD}`);
-          continue;
-        }
-
-        let amountEth = usdAmount / ethPrice;
+        const amountEth = risk.calculatePositionSize(score, available, ethPrice);
         if (amountEth <= 0) {
+          console.log(`Skipping ${symbol} — below $${MIN_TRADE_USD}`);
           continue;
         }
 
@@ -207,7 +201,10 @@ async function checkTrades(entries, ethPrice) {
         }
         let amountsOut;
         try {
-          const out = await router.getAmountsOut(ethers.parseEther(amountEth.toString()), [WETH, tokenAddr]);
+          const out = await router.getAmountsOut(
+            ethers.parseEther(amountEth.toFixed(6)),
+            [WETH, tokenAddr]
+          );
           amountsOut = out && out[1];
         } catch (e) {
           logError(`Liquidity check failed for ${symbol} | ${e.message}`);

--- a/ai-trading-bot/risk.js
+++ b/ai-trading-bot/risk.js
@@ -28,9 +28,11 @@ function takeProfit(symbol, price) {
   return false;
 }
 
-function calculatePositionSize(score, capital) {
-  const percent = score * 0.05;
-  const usd = capital * percent;
-  return usd < 10 ? 0 : usd;
+function calculatePositionSize(score, ethBalance, ethPrice) {
+  const s = Math.max(1, Math.min(score, 3));
+  const allocation = 0.2 * (s / 3); // max 20% of wallet when score is 3
+  const amountEth = ethBalance * allocation;
+  if (amountEth * ethPrice < 10 || amountEth < 0.0045) return 0;
+  return amountEth;
 }
 module.exports = { updateEntry, stopLoss, takeProfit, getEntry, calculatePositionSize };


### PR DESCRIPTION
## Summary
- scale trade size by confidence score with 20% max allocation
- skip trades below $10/0.0045 ETH
- use fixed precision values when quoting liquidity

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68577c158acc8332976623ced12ea7cd