### PR TITLE
Add swap simulation and concise trade logging

### DIFF
--- a/ai-trading-bot/risk.js
+++ b/ai-trading-bot/risk.js
@@ -29,6 +29,7 @@ function takeProfit(symbol, price) {
 }
 
 function calculatePositionSize(score, ethBalance, ethPrice) {
+  ethPrice = ethPrice || 3500;
   const s = Math.max(1, Math.min(score, 3));
   const allocation = 0.2 * (s / 3); // max 20% of wallet when score is 3
   const amountEth = ethBalance * allocation;


### PR DESCRIPTION
## Summary
- simulate swaps before sending real trades
- cut down console noise and skip trades below $10
- check trade value using fallback ETH price
- use new simulation when trading real mode only

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685788f14af883329d9e04be1985ac79