### PR TITLE
Enhance token handling and stability

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -34,14 +34,15 @@ async function refreshTokenList() {
   }
 }
 
-async function withRetry(fn, retries = 3, delay = 1500) {
+async function withRetry(fn, retries = 3, delay = 1000) {
   for (let i = 0; i < retries; i++) {
     try {
       return await fn();
     } catch (err) {
-      if (err.code === -32005 && i < retries - 1) {
-        console.warn(`[RETRY] RPC rate limit hit. Retrying in ${delay}ms...`);
-        await new Promise(res => setTimeout(res, delay));
+      if (i < retries - 1) {
+        const d = delay * 2 ** i;
+        console.warn(`[RETRY] ${err.message || err}. Waiting ${d}ms`);
+        await new Promise(res => setTimeout(res, d));
       } else {
         throw err;
       }
@@ -269,5 +270,9 @@ function main() {
   }, 60 * 1000);
 }
 
-main();
+try {
+  main();
+} catch (err) {
+  logError(`Startup failure | ${err.stack || err}`);
+}
 

--- a/ai-trading-bot/config.js
+++ b/ai-trading-bot/config.js
@@ -1,27 +1,10 @@
 module.exports = {
   SLIPPAGE: 0.005, // 0.5%
+  // Start with a minimal list. Additional tokens are loaded dynamically
+  // from the CoinGecko API at runtime via dynamicTokens.js
   coins: [
-    'ETH',     // Ethereum
-    'WETH',    // Wrapped Ether
-    'LINK',    // Chainlink
-    'UNI',     // Uniswap
-    'ARB',     // Arbitrum
-    'MATIC',   // Polygon
-    'WBTC',    // Wrapped Bitcoin
-    'AAVE',    // Aave
-    'COMP',    // Compound
-    'SUSHI',   // SushiSwap
-    'LDO',     // Lido DAO
-    'MKR',     // Maker
-    'CRV',     // Curve DAO
-    'GRT',     // The Graph
-    'ENS',     // Ethereum Name Service
-    '1INCH',   // 1inch
-    'DYDX',    // dYdX
-    'BAL',     // Balancer
-    'BNT',     // Bancor
-    'OCEAN'    // Ocean Protocol
-    // Removed BAND, RLC, AMPL, STORJ for now due to address or liquidity issues
+    'ETH',  // Ethereum
+    'WETH'  // Wrapped Ether
   ],
   RSI_PERIOD: 14,
   MACD_FAST: 12,

--- a/ai-trading-bot/tokens.js
+++ b/ai-trading-bot/tokens.js
@@ -3,7 +3,9 @@
 // Addresses are normalized using ethers.utils.getAddress and validated at load
 // time to ensure checksum correctness.
 
-const { getAddress } = require('ethers').utils;
+// ethers v6 exposes helpers under ethers/lib/utils when using CommonJS.
+// Using this import avoids pulling in the full library during require.
+const { getAddress } = require('ethers/lib/utils');
 
 const TOKENS = {
   WETH: getAddress('0xC02aaA39b223fe8d0a0e5c4f27ead9083c756cc2'),


### PR DESCRIPTION
## Summary
- load tokens dynamically and validate on startup
- use ethers v6 helper import for checksummed addresses
- simplify default token list
- implement generic retry logic with exponential backoff
- add Uniswap liquidity validation and improved trade logging
- guard main entry point with try/catch

## Testing
- `node --check ai-trading-bot/bot.js`
- `node --check ai-trading-bot/trade.js`
- `node --check ai-trading-bot/tokens.js`

------
https://chatgpt.com/codex/tasks/task_e_6858909d0f648332bbdc9478bc54daff