### PR TITLE
Fix trade limits and use WETH base

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -29,7 +29,7 @@ async function refreshTokenList() {
   const tokens = await getValidTokens();
   if (tokens && tokens.length) {
     validTokens = tokens;
-    config.coins = ['ETH', 'WETH', ...validTokens];
+    config.coins = ['WETH', ...validTokens];
     console.log(`[TOKENS] Loaded ${validTokens.length} tradable tokens`);
   }
 }
@@ -188,7 +188,7 @@ async function checkTrades(entries, ethPrice, isTop) {
 
     if (!activeTrades[symbol]) {
       if (strategy.shouldBuy(symbol, closing)) {
-        const balance = await trade.getEthBalance();
+        const balance = await trade.getWethBalance();
         const feeData = await withRetry(() => provider.getFeeData());
         const gasPrice = feeData.gasPrice || ethers.parseUnits('0', 'gwei');
         const gasCost = Number(ethers.formatEther(gasPrice * 210000n));
@@ -196,7 +196,7 @@ async function checkTrades(entries, ethPrice, isTop) {
 
         const amountEth = risk.calculatePositionSize(score, available, ethPrice || 3500);
         if (amountEth <= 0) {
-          console.log(`[SKIP] Trade amount below $${MIN_TRADE_USD} for ${symbol}`);
+          console.log(`[TRADE] Skipped ${symbol}: trade amount below $${MIN_TRADE_USD}`);
           continue;
         }
 

--- a/ai-trading-bot/config.js
+++ b/ai-trading-bot/config.js
@@ -3,8 +3,8 @@ module.exports = {
   // Start with a minimal list. Additional tokens are loaded dynamically
   // from the CoinGecko API at runtime via top25.js
   coins: [
-    'ETH',  // Ethereum
-    'WETH'  // Wrapped Ether
+    // Use WETH exclusively as the base asset
+    'WETH'
   ],
   RSI_PERIOD: 14,
   MACD_FAST: 12,

--- a/ai-trading-bot/top25.js
+++ b/ai-trading-bot/top25.js
@@ -74,8 +74,8 @@ async function validateToken(token, ethPrice) {
   const token0 = await pair.token0();
   const wethReserve = token0.toLowerCase() === TOKENS.WETH.toLowerCase() ? reserves[0] : reserves[1];
   const wethAmt = Number(ethers.formatEther(wethReserve));
-  if (wethAmt * ethPrice < 500) {
-    console.warn(`\u274c Liquidity <$500 for ${token.symbol.toUpperCase()}`);
+  if (wethAmt * ethPrice < 50) {
+    console.log(`[LIQUIDITY] Skipped ${token.symbol.toUpperCase()}: liquidity < $50`);
     return null;
   }
 


### PR DESCRIPTION
## Summary
- lower liquidity threshold when validating tokens
- use WETH only and enforce minimum trade amount
- skip trades below $10 and log skip message
- drop ETH from default coin list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858a35cf53c8332a3a8d6769f8ed403