### PR TITLE
Improve token validation logic

### DIFF
--- a/ai-trading-bot/top25.js
+++ b/ai-trading-bot/top25.js
@@ -41,13 +41,18 @@ async function fetchEthPrice() {
 async function validateToken(token, ethPrice) {
   let address = token.platforms && token.platforms.ethereum;
   if (!address) {
+    // Fall back to a statically configured address if available
+    address = TOKENS[token.symbol.toUpperCase()];
+  }
+  if (!address) {
     try {
+      // Attempt ENS lookup as a last resort
       address = await provider.resolveName(`${token.symbol}.eth`);
     } catch {}
-    if (!address) {
-      console.warn(`\u274c Missing address for ${token.symbol.toUpperCase()}`);
-      return null;
-    }
+  }
+  if (!address) {
+    console.warn(`\u274c Missing address for ${token.symbol.toUpperCase()}`);
+    return null;
   }
   let checksummed;
   try {


### PR DESCRIPTION
## Summary
- let `validateToken` fallback to addresses from `tokens.js`
- attempt ENS lookup only if necessary

## Testing
- `node -c top25.js`
- `node bot.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6858a758f5348332a585c8d9a9aa0d75