### PR TITLE
Enhance trading robustness and logging

### DIFF
--- a/ai-trading-bot/top25.js
+++ b/ai-trading-bot/top25.js
@@ -133,4 +133,8 @@ async function getValidTokens() {
   }
 }
 
-module.exports = { getValidTokens };
+function getTop25TradableTokens() {
+  return getValidTokens();
+}
+
+module.exports = { getValidTokens, getTop25TradableTokens };


### PR DESCRIPTION
## Summary
- support `getTop25TradableTokens`
- track session PnL in log header
- skip disabled tokens after repeated failures
- return structured results from trade helpers
- refresh token list without resetting history

## Testing
- `npm test --silent`
- `npm run lint --silent`
- `node -c ai-trading-bot/bot.js`
- `node -c ai-trading-bot/top25.js`
- `node -c ai-trading-bot/trade.js`


------
https://chatgpt.com/codex/tasks/task_e_6858b313735c8332b55f61e20a36747b