### PR TITLE
Improve buy confirmation logging

### DIFF
--- a/ai-trading-bot/trade.js
+++ b/ai-trading-bot/trade.js
@@ -291,13 +291,12 @@ async function buy(amountEth, path, token, opts = {}) {
       )
     );
     const receipt = await tx.wait();
-    console.log(`✅ Buy TX sent: ${tx.hash}`);
     const afterBal = await getTokenBalance(tokenAddr, walletAddress, token);
     const diff = afterBal - beforeBal;
     if (diff > 0) {
-      console.log(`🎉 Bought ${diff.toFixed(2)} ${token} successfully`);
+      console.log(`✅ Bought ${diff.toFixed(2)} ${token} | TX: ${tx.hash}`);
     } else {
-      console.log(`❌ No ${token} received`);
+      console.log(`❌ Buy failed – no ${token} received`);
     }
     appendLog({ time: new Date().toISOString(), action: 'BUY', token, amountEth: amt, tx: tx.hash });
     return { success: true, tx: tx.hash };


### PR DESCRIPTION
## Summary
- log the amount of tokens purchased after each buy
- show a clear failure message if no tokens were received

## Testing
- `node -c ai-trading-bot/trade.js`
- `node -e "require('./ai-trading-bot/trade.js');"` *(fails: Cannot find module 'ethers')*

------
https://chatgpt.com/codex/tasks/task_e_6858dc543b848332ac59a8b89c1ecf40