### PR TITLE
Add trade verification and fixed sizing

### DIFF
--- a/ai-trading-bot/risk.js
+++ b/ai-trading-bot/risk.js
@@ -30,8 +30,7 @@ function takeProfit(symbol, price) {
 
 function calculatePositionSize(score, ethBalance, ethPrice) {
   ethPrice = ethPrice || 3500;
-  const s = Math.max(1, Math.min(score, 3));
-  const allocation = 0.15 * (s / 3); // cap at 15% of wallet
+  const allocation = config.TRADE_ALLOCATION || 0.15;
   const amountEth = ethBalance * allocation;
   if (amountEth * ethPrice < 10 || amountEth <= 0) return 0;
   return amountEth;


### PR DESCRIPTION
## Summary
- allocate a fixed 15% of WETH balance for each trade
- require a minimum received token amount after a buy
- report failed or small buys

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6858e02ee8908332b055cdd093d40dc9