### PR TITLE
Fix buy logic

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -290,14 +290,14 @@ async function checkTrades(entries, ethPrice, isTop) {
         let res;
         if (!paper) {
           try {
-            res = await trade.buy(amountEth, [WETH, tokenAddr], symbol, { simulate: isTop, dryRun: DRY_RUN });
+            res = await trade.buy(symbol, { simulate: isTop, dryRun: DRY_RUN });
             if (!res.success) recordFailure(symbol, res.reason);
           } catch (err) {
             logError(`Failed to trade ETH \u2192 ${symbol} | ${err.message}`);
             recordFailure(symbol, err.message);
           }
         } else {
-          res = await trade.buy(amountEth, [WETH, tokenAddr], symbol, { simulate: isTop, dryRun: true });
+          res = await trade.buy(symbol, { simulate: isTop, dryRun: true });
         }
         if (res && res.success) {
           risk.updateEntry(symbol, price);


### PR DESCRIPTION
## Summary
- refactor buy logic to always use 15% of WETH balance
- enforce minimum balance checks and approval flow
- log actions in Pacific time
- update bot to use new buy signature

## Testing
- `node -e "require('./ai-trading-bot/trade.js')"` *(fails: Cannot find module 'ethers')*

------
https://chatgpt.com/codex/tasks/task_e_6858ee593a24833293adeb4b8f753666