### PR TITLE
Improve token address lookup and pair search

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -290,7 +290,10 @@ async function checkTrades(entries, ethPrice, isTop) {
           continue;
         }
 
-        const tokenAddr = TOKENS[symbol.toUpperCase()];
+        let tokenAddr = TOKENS[symbol.toUpperCase()];
+        if (!tokenAddr && TOKENS.getTokenAddress) {
+          tokenAddr = await TOKENS.getTokenAddress(symbol);
+        }
         if (!tokenAddr) {
           console.log("Token address is null, skipping trade.");
           continue;
@@ -325,7 +328,10 @@ async function checkTrades(entries, ethPrice, isTop) {
         let res;
         if (!paper) {
           try {
-            const tokenAddr = TOKENS[symbol.toUpperCase()];
+            let tokenAddr = TOKENS[symbol.toUpperCase()];
+            if (!tokenAddr && TOKENS.getTokenAddress) {
+              tokenAddr = await TOKENS.getTokenAddress(symbol);
+            }
             if (!tokenAddr) {
               console.log("Token address is null, skipping trade.");
             } else {
@@ -337,7 +343,10 @@ async function checkTrades(entries, ethPrice, isTop) {
             recordFailure(symbol, err.message);
           }
         } else {
-          const tokenAddr = TOKENS[symbol.toUpperCase()];
+          let tokenAddr = TOKENS[symbol.toUpperCase()];
+          if (!tokenAddr && TOKENS.getTokenAddress) {
+            tokenAddr = await TOKENS.getTokenAddress(symbol);
+          }
           if (tokenAddr) {
             res = await trade.sellToken(symbol);
           }

--- a/ai-trading-bot/datafeeds.js
+++ b/ai-trading-bot/datafeeds.js
@@ -25,7 +25,9 @@ const ID_MAP = {
   BAND: 'band-protocol',
   RLC: 'iexec-rlc',
   AMPL: 'ampleforth',
-  STORJ: 'storj'
+  STORJ: 'storj',
+  USDC: 'usd-coin',
+  USDT: 'tether'
 };
 
 async function getPrices() {

--- a/ai-trading-bot/top25.js
+++ b/ai-trading-bot/top25.js
@@ -37,6 +37,9 @@ async function validateToken(token, ethPrice) {
     // Fall back to a statically configured address if available
     address = TOKENS[token.symbol.toUpperCase()];
   }
+  if (!address && TOKENS.getTokenAddress) {
+    address = await TOKENS.getTokenAddress(token.symbol);
+  }
   if (!address) {
     try {
       // Attempt ENS lookup as a last resort


### PR DESCRIPTION
## Summary
- add USDC/USDT addresses and dynamic address lookup via CoinGecko
- retry pair search against USDC if WETH pair not found
- log token addresses and pair searches when DEBUG_PAIRS is enabled
- ensure bot and token validation use dynamic address resolution

## Testing
- `node -e "require('./ai-trading-bot/tokens.js')"` *(fails: Cannot find module 'ethers')*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6859fb0b9120833292b86829a26b7ce4