### PR TITLE
Dynamic Arbitrum token validation

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -8,7 +8,7 @@ const path = require('path');
 const { ethers, getAddress } = require('ethers');
 const config = require('./config');
 const TOKENS = require('./tokens');
-const { getValidTokens, getTop25TradableTokens } = require('./top25');
+const { getValidTokens } = require('./top25');
 
 const MIN_TRADE_USD = 10;
 console.debug = () => {};
@@ -39,8 +39,10 @@ const activePositions = new Set();
 const lastScores = {};
 
 async function refreshTokenList(initial = false) {
-  const tokens = await getTop25TradableTokens();
-  if (!tokens || !tokens.length) return;
+  const list = await getValidTokens();
+  if (!list || !list.length) return;
+  list.sort((a, b) => b.score - a.score);
+  const tokens = list.slice(0, 25).map(t => t.symbol);
 
   if (initial || !validTokens.length) {
     validTokens = tokens.slice(0, 25);

--- a/ai-trading-bot/trade.js
+++ b/ai-trading-bot/trade.js
@@ -605,4 +605,12 @@ async function autoWrapOrUnwrap() {
   }
 }
 
-module.exports = { buy, sellToken, getWethBalance, getTokenBalance, autoWrapOrUnwrap };
+module.exports = {
+  buy,
+  sellToken,
+  getWethBalance,
+  getTokenBalance,
+  autoWrapOrUnwrap,
+  validateLiquidity,
+  getTokenUsdPrice
+};


### PR DESCRIPTION
## Summary
- dynamically load the Arbitrum token list
- validate each token address, liquidity and price
- sort tokens by score and return the top results
- expose needed helpers from trade module
- update bot to rank tokens by score before trading

## Testing
- `node ai-trading-bot/test.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685a2dc6d8e88332a27bd35054fb2fa7