### PR TITLE
Update token validation logic

### DIFF
--- a/ai-trading-bot/top25.js
+++ b/ai-trading-bot/top25.js
@@ -98,6 +98,7 @@ async function getValidTokens() {
       const res = await validateToken(token, ethPrice);
       if (res) valid.push(res);
     }
+    console.log(`\u2705 Validated ${valid.length} tokens`);
 
     valid.sort((a, b) => b.score - a.score);
 
@@ -105,7 +106,6 @@ async function getValidTokens() {
       cachedTokens = valid;
       lastFetched = Date.now();
     }
-    console.log(`\u2705 Validated ${valid.length} tokens`);
     return [...cachedTokens];
   } catch (err) {
     // Silently return cached results on failure

--- a/ai-trading-bot/trade.js
+++ b/ai-trading-bot/trade.js
@@ -327,8 +327,8 @@ async function validateLiquidity(tokenA, tokenB, symbol) {
     } else {
       liquidityUsd = Number(ethers.formatEther(reserve));
     }
-    if (liquidityUsd < 50) {
-      console.debug(`[LIQUIDITY] Skipped ${symbol}: liquidity < $50`);
+    if (liquidityUsd < 10) {
+      console.debug(`[LIQUIDITY] Skipped ${symbol}: liquidity < $10`);
       return false;
     }
     return true;


### PR DESCRIPTION
## Summary
- keep validating every token in the list
- show how many tokens were validated
- loosen liquidity filter in trade.js to allow pairs with at least $10 liquidity

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685a356115948332a87ed963c27f3e5f