### PR TITLE
Allow more low liquidity tokens

### DIFF
--- a/ai-trading-bot/top25.js
+++ b/ai-trading-bot/top25.js
@@ -98,9 +98,13 @@ async function getValidTokens() {
       const res = await validateToken(token, ethPrice);
       if (res) valid.push(res);
     }
-    console.log(`\u2705 Validated ${valid.length} tokens`);
+
+    console.log(
+      `\u2705 Validated ${valid.length} of ${tokenList.length} tokens (minimum $5 liquidity)`
+    );
 
     valid.sort((a, b) => b.score - a.score);
+    console.log(`\u2705 Using top 25 tokens for trading`);
 
     if (valid.length) {
       cachedTokens = valid;

--- a/ai-trading-bot/trade.js
+++ b/ai-trading-bot/trade.js
@@ -327,8 +327,8 @@ async function validateLiquidity(tokenA, tokenB, symbol) {
     } else {
       liquidityUsd = Number(ethers.formatEther(reserve));
     }
-    if (liquidityUsd < 10) {
-      console.debug(`[LIQUIDITY] Skipped ${symbol}: liquidity < $10`);
+    if (liquidityUsd < 5) {
+      console.debug(`[LIQUIDITY] Skipped ${symbol}: liquidity < $5`);
       return false;
     }
     return true;


### PR DESCRIPTION
## Summary
- relax liquidity check so small-cap tokens can be used
- show counts of validated tokens

## Testing
- `npm --prefix ai-trading-bot install` *(fails: 403 Forbidden)*
- `node ai-trading-bot/test.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685a385cd7e483329e94854ff968e348