### PR TITLE
Fix missing token loader

### DIFF
--- a/ai-trading-bot/tokens.js
+++ b/ai-trading-bot/tokens.js
@@ -36,6 +36,10 @@ const TOKENS = {
 
 const FALLBACK_TOKENS = TOKENS;
 
+async function load() {
+  return TOKENS;
+}
+
 function getTokenAddress(symbol) {
   return TOKENS[symbol.toUpperCase()] || null;
 }
@@ -47,6 +51,7 @@ function getValidTokens() {
 }
 
 module.exports = TOKENS;
+module.exports.load = load;
 module.exports.getTokenAddress = getTokenAddress;
 module.exports.getValidTokens = getValidTokens;
 module.exports.FALLBACK_TOKENS = FALLBACK_TOKENS;


### PR DESCRIPTION
## Summary
- add placeholder `load()` method in tokens module to prevent runtime error

## Testing
- `node ai-trading-bot/test.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685a7ab44a148332b137b6de7e135b5e