### PR TITLE
On-chain pricing and UI cleanup

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -408,41 +408,7 @@ async function loop() {
       lastGroupBCheck = now;
     }
 
-    // Table 1: Holdings View
-    const portfolio = [];
-    for (const symbol of activePositions) {
-      let tokenAddr = TOKENS[symbol.toUpperCase()];
-      if (!tokenAddr && TOKENS.getTokenAddress) {
-        tokenAddr = await TOKENS.getTokenAddress(symbol);
-      }
-      if (!tokenAddr) continue;
-      const qty = await trade.getTokenBalance(tokenAddr, walletAddress, symbol);
-      if (qty <= 0) continue;
-      const buyPrice = risk.getEntry(symbol) || 0;
-      const marketPrice = prices[symbol.toLowerCase()] || 0;
-      const pnl = ((marketPrice - buyPrice) * qty).toFixed(2);
-      portfolio.push({
-        Symbol: symbol,
-        'Buy Price': `$${buyPrice.toFixed(2)}`,
-        'Market Price': `$${marketPrice.toFixed(2)}`,
-        'PnL ($)': `$${pnl}`
-      });
-    }
-
-    console.log('\n=== 📦 Portfolio Holdings ===');
-    console.table(portfolio);
-
-    // Table 2: Top 5 Signals
-    const picks = evaluations.slice(0, 5);
-    const rows = picks.map((t, idx) => [
-      String(idx + 1),
-      t.symbol,
-      `$${t.price.toFixed(2)}`,
-      t.signals && t.signals.length ? t.signals.join(', ') : '-'
-    ]);
-
-    console.log('\n=== 📊 Top 5 Picks ===');
-    console.log(formatTable(rows, ['#', 'Symbol', 'Price', 'Matched']));
+    // Display only the summary table generated in renderSummary
   } catch (err) {
     logError(`Loop failure | ${err.stack || err}`);
   }

--- a/ai-trading-bot/config.js
+++ b/ai-trading-bot/config.js
@@ -1,7 +1,7 @@
 module.exports = {
   SLIPPAGE: 0.01, // 1% slippage tolerance
   // Start with a minimal list. Additional tokens are loaded dynamically
-  // from the CoinGecko API at runtime via top25.js
+  // from on-chain data at runtime via top25.js
   coins: [
     // Use WETH exclusively as the base asset
     'WETH'

--- a/ai-trading-bot/datafeeds.js
+++ b/ai-trading-bot/datafeeds.js
@@ -1,52 +1,20 @@
-const axios = require('axios');
-
-// Mapping from token symbol to CoinGecko id
-const ID_MAP = {
-  ETH: 'ethereum',
-  LINK: 'chainlink',
-  UNI: 'uniswap',
-  ARB: 'arbitrum',
-  MATIC: 'matic-network',
-  WBTC: 'wrapped-bitcoin',
-  AAVE: 'aave',
-  COMP: 'compound-governance-token',
-  SNX: 'synthetix-network-token',
-  SUSHI: 'sushi',
-  LDO: 'lido-dao',
-  MKR: 'maker',
-  CRV: 'curve-dao-token',
-  GRT: 'the-graph',
-  ENS: 'ethereum-name-service',
-  '1INCH': '1inch',
-  DYDX: 'dydx',
-  BAL: 'balancer',
-  BNT: 'bancor',
-  OCEAN: 'ocean-protocol',
-  BAND: 'band-protocol',
-  RLC: 'iexec-rlc',
-  AMPL: 'ampleforth',
-  STORJ: 'storj',
-  USDC: 'usd-coin',
-  USDT: 'tether'
-};
+const trade = require('./trade');
+const config = require('./config');
 
 async function getPrices() {
-  try {
-    const ids = Object.values(ID_MAP).join(',');
-    const res = await axios.get(
-      "https://api.coingecko.com/api/v3/simple/price",
-      { params: { ids, vs_currencies: "usd" } }
-    );
-    const prices = {};
-    for (const [symbol, id] of Object.entries(ID_MAP)) {
-      prices[symbol.toLowerCase()] = res.data[id]?.usd;
+  const prices = {};
+  const ethPrice = await trade.getEthPrice();
+  prices.eth = ethPrice;
+  const coins = config.coins || [];
+  for (const symbol of coins) {
+    if (['ETH', 'WETH'].includes(symbol)) {
+      prices[symbol.toLowerCase()] = ethPrice;
+      continue;
     }
-    return prices;
-  } catch (err) {
-    console.error("\u274c Price fetch error:", err.message);
-    return null;
+    const p = await trade.getTokenUsdPrice(symbol);
+    if (p) prices[symbol.toLowerCase()] = p;
   }
+  return prices;
 }
 
-module.exports = { getPrices, ID_MAP };
-
+module.exports = { getPrices };


### PR DESCRIPTION
## Summary
- use on-chain quotes for price data
- drop CoinGecko integration
- fix config comment
- simplify data feed module
- clean up bot output tables

## Testing
- `npm test` *(fails: Missing script)*
- `node -e "require('./ai-trading-bot/datafeeds').getPrices().then(p=>console.log(p)).catch(err=>console.error('ERR',err))"` *(fails: module not found because dependencies aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_685aec925ae883328b959cacac1f3318