### PR TITLE
Fix ETH price fetch export

### DIFF
--- a/ai-trading-bot/trade.js
+++ b/ai-trading-bot/trade.js
@@ -616,5 +616,6 @@ module.exports = {
   getTokenBalance,
   autoWrapOrUnwrap,
   validateLiquidity,
+  getEthPrice,
   getTokenUsdPrice
 };


### PR DESCRIPTION
## Summary
- export `getEthPrice` from `trade.js`

## Testing
- `node ai-trading-bot/test.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685af49c70e883329b07f5cc2e9ce3b4