### PR TITLE
Fix token address validation

### DIFF
--- a/ai-trading-bot/tokens.js
+++ b/ai-trading-bot/tokens.js
@@ -2,7 +2,10 @@ const ethers = require('ethers');
 
 function safeGetAddress(addr, symbol) {
   try {
-    return ethers.getAddress(addr);
+    // Normalize case before checksum verification to tolerate non-checksummed
+    // addresses in the built-in list. This lets ethers.js compute the correct
+    // EIP-55 checksum instead of throwing an error.
+    return ethers.getAddress(addr.toLowerCase());
   } catch {
     console.error(`❌ Invalid address: ${symbol} - ${addr}`);
     return null;


### PR DESCRIPTION
## Summary
- normalize address case before checksum validation to fix invalid address errors

## Testing
- `node ai-trading-bot/test.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685b05c6ab8c83328054f91ffc5d11ec