### PR TITLE
Enhance logging for zero-score tokens

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -311,7 +311,8 @@ async function evaluate(prices, wethBal, ethPrice) {
     // console.log(`[${ts}] Scanning ${index + 1}/${totalScans}: ${symbol}`);
     const price = prices[symbol.toLowerCase()];
     if (!price) {
-      if (config.debugTokens) console.log(`❌ Price missing for ${symbol}`);
+      console.log(`⚠️ No price data for ${symbol}`);
+      res.push({ symbol, price: 0, score: 0, signals: [], closing: [] });
       continue;
     }
     if (!history[symbol]) history[symbol] = [];
@@ -320,6 +321,9 @@ async function evaluate(prices, wethBal, ethPrice) {
     const closing = history[symbol];
     const { score, signals } = strategy.score(closing);
     lastScores[symbol] = score;
+    if (score === 0) {
+      console.log(`Skipping ${symbol}: score = 0`);
+    }
     if (config.debugTokens) {
       console.log(`💡 TOKEN LOOP: ${symbol}, score: ${score}`);
     }
@@ -348,7 +352,7 @@ async function checkTrades(entries, ethPrice, isTop) {
   }
 
     if (score < (config.signalThreshold || 2) && !process.env.AGGRESSIVE) {
-      if (config.debugTokens) console.log(`⚠️ No trade signal for ${symbol}`);
+      console.log(`Skipping ${symbol}: score = ${score}`);
       continue;
     }
 

--- a/ai-trading-bot/config.js
+++ b/ai-trading-bot/config.js
@@ -20,5 +20,10 @@ module.exports = {
   cacheHours: 24,
   tokenCount: 50,
   debugTokens: false,
-  signalThreshold: 2
+  signalThreshold: 2,
+  aggressive: true
 };
+
+if (!process.env.AGGRESSIVE) {
+  process.env.AGGRESSIVE = 'true';
+}

--- a/ai-trading-bot/strategy.js
+++ b/ai-trading-bot/strategy.js
@@ -69,6 +69,7 @@ function analyze(symbol, prices) {
   }
 
   const aggressive = process.env.AGGRESSIVE === 'true';
+  console.log(`[STRATEGY] ${symbol} => signals:`, signals);
   if (config.debugTokens) {
     if (signals.length) {
       console.log(`✅ SIGNAL MATCH: ${symbol}: [${signals.join(', ')}]`);
@@ -77,7 +78,7 @@ function analyze(symbol, prices) {
     }
   }
 
-  if ((aggressive && signals.length >= 2) || signals.length >= 3) {
+  if ((aggressive && signals.length >= 1) || signals.length >= 2) {
     return { action: 'BUY', confidence: signals.length, reasons: signals };
   }
 

--- a/ai-trading-bot/top25.js
+++ b/ai-trading-bot/top25.js
@@ -146,6 +146,13 @@ async function validateToken(token, ethPrice) {
       return null;
     }
 
+    if (typeof trade.getTokenPriceHistory === 'function') {
+      const hist = await trade.getTokenPriceHistory(token.symbol);
+      if (!hist || hist.length < 14) {
+        console.log(`⚠️ Not enough price history for ${token.symbol.toUpperCase()}`);
+      }
+    }
+
     TOKENS[token.symbol.toUpperCase()] = checksummed;
     if (config.debugTokens) console.log(`✅ Validated ${token.symbol.toUpperCase()}`);
     return { symbol: token.symbol.toUpperCase(), address: checksummed, score: price };


### PR DESCRIPTION
## Summary
- tweak aggressive mode configuration
- add strategy signal logs and lower buy threshold
- surface missing price data and zero scores
- warn about insufficient price history

## Testing
- `node ai-trading-bot/test.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685b160558808332a9901475ee788f31