### PR TITLE
Improve price logging and token list filtering

### DIFF
--- a/ai-trading-bot/tokens.js
+++ b/ai-trading-bot/tokens.js
@@ -74,7 +74,7 @@ function getTokenAddress(symbol) {
 
 function getValidTokens() {
   return Object.entries(TOKENS)
-    .filter(([, addr]) => addr !== null)
+    .filter(([key, val]) => typeof val === 'string' && val !== null && val.startsWith('0x'))
     .map(([symbol, address]) => ({ symbol, address }));
 }
 


### PR DESCRIPTION
## Summary
- filter out helper functions from the token list
- log token USD price when retrieval succeeds

## Testing
- `npm test` *(fails: module 'axios' not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b20b62520833284dab02c15ba5f9c