### PR TITLE
Improve token validation & add startup checks

### DIFF
--- a/ai-trading-bot/testTokens.js
+++ b/ai-trading-bot/testTokens.js
@@ -1,0 +1,39 @@
+try { require('dotenv').config(); } catch {}
+const { ethers } = require('ethers');
+const fs = require('fs');
+const path = require('path');
+const trade = require('./trade');
+const TOKENS = require('./tokens');
+const { getValidTokens } = require('./top25');
+
+async function run() {
+  const list = await getValidTokens(process.argv.includes('--force-refresh'));
+  let success = 0;
+  const failures = [];
+  for (const t of list) {
+    let addr;
+    try {
+      addr = ethers.getAddress(t.address);
+    } catch {
+      failures.push(`${t.symbol} failed (invalid address)`);
+      continue;
+    }
+    const hasLiquidity = await trade.validateLiquidity(TOKENS.WETH, addr, t.symbol);
+    if (!hasLiquidity) {
+      failures.push(`${t.symbol} failed (no liquidity)`);
+      continue;
+    }
+    const price = await trade.getTokenUsdPrice(t.symbol);
+    if (!price) {
+      failures.push(`${t.symbol} failed (price fetch failed)`);
+      continue;
+    }
+    success++;
+  }
+  console.log(`✅ ${success}/${list.length} tokens validated successfully.`);
+  failures.forEach(f => console.log(`❌ ${f}`));
+}
+
+run().catch(err => {
+  console.error('Token test error:', err.message);
+});

--- a/ai-trading-bot/top25.js
+++ b/ai-trading-bot/top25.js
@@ -82,7 +82,10 @@ function saveCache(tokens) {
 
 async function fetchTokenList() {
   try {
-    const { data } = await axios.get(TOKEN_LIST_URL, { timeout: 15000 });
+    const { data } = await withRetry(
+      () => axios.get(TOKEN_LIST_URL, { timeout: 15000 }),
+      3
+    );
     if (!data || !Array.isArray(data.tokens)) return [...FALLBACK_LIST];
     const list = [];
     const seen = new Set();


### PR DESCRIPTION
## Summary
- add retry logic when downloading GitHub token list
- add startup test step to validate cached tokens
- provide standalone `testTokens.js` util

## Testing
- `npm test` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_685b24d656dc83329f19bd037e783749