### PR TITLE
Add token validation and logging utilities

### DIFF
--- a/ai-trading-bot/logger.js
+++ b/ai-trading-bot/logger.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+const logDir = path.join(__dirname, '..', 'logs');
+const logFile = path.join(logDir, 'system.log');
+
+function ensureDir() {
+  try { fs.mkdirSync(logDir, { recursive: true }); } catch {}
+}
+
+function write(line) {
+  ensureDir();
+  fs.appendFileSync(logFile, line + '\n');
+}
+
+function log(message) {
+  const ts = new Date().toISOString();
+  write(`[${ts}] ${message}`);
+}
+
+function error(err) {
+  const msg = err instanceof Error ? err.stack || err.message : err;
+  log(msg);
+}
+
+module.exports = { log, error };

--- a/ai-trading-bot/rawTokens.json
+++ b/ai-trading-bot/rawTokens.json
@@ -1,0 +1,7 @@
+[
+  {"symbol":"WETH","address":"0x82af49447d8a07e3bd95bd0d56f35241523fbab1","feed":"0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612"},
+  {"symbol":"USDC","address":"0xaf88d065e77c8cc2239327c5edb3a432268e5831","feed":"0x6ce185860a4963106506C203335A2910413708e9"},
+  {"symbol":"USDT","address":"0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9","feed":"0x3f3f5dF88dC9F13eac63DF89EC16ef6e7E25DdE7"},
+  {"symbol":"DAI","address":"0xda10009cbd5d07dd0cecc66161fc93d7c9000da1","feed":"0x678df3415fc31947dA4324eC63212874be5a82f8"},
+  {"symbol":"ARB","address":"0x912CE59144191C1204e64559FE8253a0e49E6548","feed":"0xb2A824043730FE05F3DA2efafa1cbBE83fa548D6"}
+]

--- a/ai-trading-bot/tokenValidator.js
+++ b/ai-trading-bot/tokenValidator.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const { ethers } = require('ethers');
+const logger = require('./logger');
+
+const provider = new ethers.JsonRpcProvider(process.env.ARB_RPC_URL);
+const feedAbi = ['function latestAnswer() view returns (int256)'];
+
+async function validate(force = false) {
+  const tokensFile = path.join(__dirname, 'tokens.json');
+  if (!force && fs.existsSync(tokensFile)) {
+    try {
+      return JSON.parse(fs.readFileSync(tokensFile));
+    } catch {
+      // continue to rebuild file
+    }
+  }
+
+  const rawFile = path.join(__dirname, 'rawTokens.json');
+  let raw = [];
+  try {
+    raw = JSON.parse(fs.readFileSync(rawFile));
+  } catch (err) {
+    logger.error(`Failed to read raw token list: ${err.message}`);
+    return [];
+  }
+
+  const valid = [];
+  for (const t of raw) {
+    try {
+      const address = ethers.getAddress(t.address);
+      const feed = ethers.getAddress(t.feed);
+      const contract = new ethers.Contract(feed, feedAbi, provider);
+      const price = await contract.latestAnswer();
+      if (!price || price === 0n) {
+        logger.log(`Skip ${t.symbol}: feed returned zero`);
+        continue;
+      }
+      valid.push({ symbol: t.symbol, address, feed });
+    } catch (err) {
+      logger.log(`Skip ${t.symbol}: ${err.message}`);
+    }
+  }
+
+  try {
+    fs.writeFileSync(tokensFile, JSON.stringify(valid, null, 2));
+    logger.log(`Saved ${valid.length} validated tokens`);
+  } catch (err) {
+    logger.error(`Failed to write tokens.json: ${err.message}`);
+  }
+
+  return valid;
+}
+
+module.exports = validate;

--- a/ai-trading-bot/tokens.json
+++ b/ai-trading-bot/tokens.json
@@ -1,0 +1,7 @@
+[
+  {"symbol":"WETH","address":"0x82af49447d8a07e3bd95bd0d56f35241523fbab1","feed":"0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612"},
+  {"symbol":"USDC","address":"0xaf88d065e77c8cc2239327c5edb3a432268e5831","feed":"0x6ce185860a4963106506C203335A2910413708e9"},
+  {"symbol":"USDT","address":"0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9","feed":"0x3f3f5dF88dC9F13eac63DF89EC16ef6e7E25DdE7"},
+  {"symbol":"DAI","address":"0xda10009cbd5d07dd0cecc66161fc93d7c9000da1","feed":"0x678df3415fc31947dA4324eC63212874be5a82f8"},
+  {"symbol":"ARB","address":"0x912CE59144191C1204e64559FE8253a0e49E6548","feed":"0xb2A824043730FE05F3DA2efafa1cbBE83fa548D6"}
+]


### PR DESCRIPTION
## Summary
- create shared `logger.js` writing to `logs/system.log`
- add `tokenValidator.js` to load/validate tokens from `rawTokens.json`
- expand `trade.js` to read dynamic tokens and use logger
- enhance `bot.js` to load validated tokens and add `--force-validate` flag
- include sample token lists

## Testing
- `npm test` *(fails: Missing script and no network access)*

------
https://chatgpt.com/codex/tasks/task_e_685c291d920483328bbf3935002960a5