### PR TITLE
Fix token validation and import path

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -12,8 +12,18 @@ const fs = require('fs');
 const path = require('path');
 const { ethers, getAddress } = require('ethers');
 const config = require('./config');
-const validateTokens = require('./tokenValidator');
+const validateTokens = require('./validator');
 const logger = require('./logger');
+
+const tokensPath = path.join(__dirname, 'tokens.json');
+let tokensData = [];
+try {
+  tokensData = JSON.parse(fs.readFileSync(tokensPath));
+} catch {}
+if (!Array.isArray(tokensData) || tokensData.length === 0) {
+  console.error('tokens.json missing or empty. Run "node validator.js" first.');
+  process.exit(1);
+}
 
 const MIN_TRADE_USD = 10;
 console.debug = () => {};

--- a/ai-trading-bot/validator.js
+++ b/ai-trading-bot/validator.js
@@ -1,42 +1,99 @@
 const fs = require('fs');
 const path = require('path');
-const axios = require('axios');
+let axios;
+try {
+  axios = require('axios');
+} catch {
+  axios = {
+    get: async url => {
+      const res = await fetch(url);
+      const data = await res.json();
+      return { data };
+    }
+  };
+}
 const { ethers } = require('ethers');
 require('dotenv').config({ path: path.join(__dirname, '.env') });
 
 const provider = new ethers.JsonRpcProvider(process.env.ARB_RPC_URL || 'https://arb1.arbitrum.io/rpc');
-const TOKENS_URL = 'https://api.1inch.io/v5.0/42161/tokens';
-const FEEDS_URL = 'https://cl-docs-addresses.web.app/feeds-arbitrum-mainnet.json';
+const TOKENS_URL =
+  'https://tokens.coingecko.com/arbitrum/all.json';
+const FEEDS_URL =
+  'https://raw.githubusercontent.com/dataalways/chainlink-feeds/main/arbitrum.json';
 
 const feedAbi = [
   'function latestAnswer() view returns (int256)',
   'function decimals() view returns (uint8)'
 ];
 
+const fallbackTokens = [
+  {
+    symbol: 'WETH',
+    address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+    feed: '0x639Fe6ab55C921f74e7fac1ee960C0B6293ba612'
+  },
+  {
+    symbol: 'USDC',
+    address: '0xaf88d065e77c8cc2239327c5edb3a432268e5831',
+    feed: '0x6ce185860a4963106506C203335A2910413708e9'
+  },
+  {
+    symbol: 'USDT',
+    address: '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9',
+    feed: '0x3f3f5dF88dC9F13eac63DF89EC16ef6e7E25DdE7'
+  },
+  {
+    symbol: 'DAI',
+    address: '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1',
+    feed: '0x678df3415fc31947dA4324eC63212874be5a82f8'
+  }
+];
+
 async function fetchTokenCandidates() {
   try {
     const { data } = await axios.get(TOKENS_URL);
-    const list = Object.values(data.tokens).slice(0, 100);
-    return list.map(t => ({ symbol: t.symbol, address: t.address }));
+    const list = data.tokens || data;
+    const arr = Array.isArray(list)
+      ? list.slice(0, 100)
+      : Object.values(list).slice(0, 100);
+    return arr.map(t => ({ symbol: t.symbol, address: t.address }));
   } catch (err) {
     console.error('Failed to fetch token list:', err.message);
-    return [];
+    try {
+      const local = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'rawTokens.json'))
+      );
+      if (Array.isArray(local) && local.length) return local;
+    } catch {}
+    console.warn('Using fallback tokens');
+    return fallbackTokens;
   }
 }
 
 async function fetchFeeds() {
   try {
     const { data } = await axios.get(FEEDS_URL);
-    // data assumed to be {entries: [{pair, feed}]}
+    const entries =
+      data.entries || data.feeds || data.data || data || [];
     const mapping = {};
-    (data.entries || []).forEach(e => {
-      const [sym] = e.pair.split('/');
-      mapping[sym.trim().toUpperCase()] = e.feed;
+    (Array.isArray(entries) ? entries : Object.values(entries)).forEach(e => {
+      const pair = e.pair || e.name || e.symbol || '';
+      const addr =
+        e.feed || e.proxy || e.address || e.proxyAddress || e.aggregator;
+      const [sym] = pair.split('/');
+      if (sym && ethers.isAddress(addr)) {
+        mapping[sym.trim().toUpperCase()] = addr;
+      }
     });
-    return mapping;
+    return Object.keys(mapping).length ? mapping : {};
   } catch (err) {
     console.error('Failed to fetch chainlink feeds:', err.message);
-    return {};
+    const local = {};
+    fallbackTokens.forEach(t => {
+      if (t.feed) local[t.symbol.toUpperCase()] = t.feed;
+    });
+    console.warn('Using fallback feeds');
+    return local;
   }
 }
 


### PR DESCRIPTION
## Summary
- fix bot.js to load `validator` instead of non-existent tokenValidator
- verify token list exists before starting bot
- use hosted token/feeds lists in validator and add fallback
- support running validator without axios present

## Testing
- `node ai-trading-bot/validator.js` *(fails: Cannot find module 'ethers')*
- `node ai-trading-bot/bot.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685caea68d74833288446aa73f1b36eb