### PR TITLE
Handle price feed errors

### DIFF
--- a/ai-trading-bot/trade.js
+++ b/ai-trading-bot/trade.js
@@ -101,8 +101,13 @@ async function getTokenUsdPrice(symbol) {
   try {
     raw = await feed.latestAnswer();
   } catch (err) {
-    const [, answer] = await feed.latestRoundData();
-    raw = answer;
+    try {
+      const [, answer] = await feed.latestRoundData();
+      raw = answer;
+    } catch (err2) {
+      console.warn(`Price fetch failed for ${symbol}: ${err2.message}`);
+      return null;
+    }
   }
   return Number(raw) / 1e8;
 }


### PR DESCRIPTION
## Summary
- gracefully handle failure when fetching token USD price

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cdf2dc6c48332af678514717fb657