### PR TITLE
Fix token validator feed checks

### DIFF
--- a/ai-trading-bot/validator.js
+++ b/ai-trading-bot/validator.js
@@ -1,10 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 const { ethers } = require('ethers');
+require('dotenv').config();
 
 const tokenListPath = path.join(__dirname, 'data', 'arbitrum.tokenlist.json');
 const feedsPath = path.join(__dirname, 'data', 'feeds.json');
 const tokensFile = path.join(__dirname, 'tokens.json');
+const rawTokensFile = path.join(__dirname, 'rawTokens.json');
 
 function loadTokens() {
   const data = JSON.parse(fs.readFileSync(tokenListPath));
@@ -25,28 +27,61 @@ function loadFeeds() {
   return map;
 }
 
-function validate() {
+async function validate() {
+  const provider = new ethers.JsonRpcProvider(process.env.ARB_RPC_URL);
+  const abi = ['function latestAnswer() view returns (int256)'];
+
   const tokens = loadTokens();
   const feeds = loadFeeds();
   const valid = [];
+  const raw = [];
+
   for (const t of tokens) {
     if (!ethers.isAddress(t.address)) continue;
     const feed = feeds[t.symbol];
-    if (feed) {
-      valid.push({ symbol: t.symbol, address: t.address, feed });
-      console.log(`Validated ${t.symbol}`);
+    const entry = { symbol: t.symbol, address: t.address };
+    if (feed) entry.feed = feed;
+
+    if (!feed) {
+      entry.reason = 'no feed';
+      console.log(`\u274c ${t.symbol} \u2192 no feed`);
+      raw.push(entry);
+      continue;
     }
+
+    const aggregator = new ethers.Contract(feed, abi, provider);
+    let price;
+    try {
+      price = await aggregator.latestAnswer();
+    } catch (err) {
+      entry.reason = err.message || 'feed error';
+      console.log(`\u274c ${t.symbol} \u2192 ${entry.reason}`);
+      raw.push(entry);
+      continue;
+    }
+
+    const num = Number(price);
+    if (!num) {
+      entry.reason = 'price=0';
+      entry.price = price ? price.toString() : '0';
+      console.log(`\u274c ${t.symbol} \u2192 price=0`);
+      raw.push(entry);
+      continue;
+    }
+
+    entry.price = price.toString();
+    valid.push({ symbol: t.symbol, address: t.address, feed });
+    raw.push(entry);
+    console.log(`\u2705 ${t.symbol}`);
   }
+
   fs.writeFileSync(tokensFile, JSON.stringify(valid, null, 2));
+  fs.writeFileSync(rawTokensFile, JSON.stringify(raw, null, 2));
   return valid;
 }
 
 if (require.main === module) {
-  try {
-    validate();
-  } catch (err) {
-    console.error(err);
-  }
+  validate().catch(err => console.error(err));
 }
 
 module.exports = validate;


### PR DESCRIPTION
## Summary
- check Chainlink feeds via `latestAnswer`
- log broken feeds
- write `tokens.json` with valid tokens only
- output all results to `rawTokens.json`

## Testing
- `node validator.js` *(fails: Cannot find module 'ethers')*

------
https://chatgpt.com/codex/tasks/task_e_685ce6552de48332a062f01c69de8dba