### PR TITLE
Fix validator feed logging

### DIFF
--- a/ai-trading-bot/validator.js
+++ b/ai-trading-bot/validator.js
@@ -77,7 +77,7 @@ async function validateTokens(tokens, feeds, provider) {
     const entry = { symbol, address: t.address };
     if (feed) entry.feed = feed;
     valid.push(entry);
-    console.log(feed ? `\u2705 ${symbol} -> ${feed}` : `\u2705 ${symbol} -> no feed`);
+    console.log(feed ? `\u2705 ${symbol} -> ${feed}` : `\u26A0\uFE0F ${symbol} -> no feed`);
   }
 
   fs.writeFileSync(tokensFile, JSON.stringify(valid, null, 2));


### PR DESCRIPTION
## Summary
- update feed logging for tokens with missing Chainlink feeds

## Testing
- `node ai-trading-bot/validator.js --debug` *(fails: Cannot find module 'ethers')*

------
https://chatgpt.com/codex/tasks/task_e_685dcfd01d2c8332913063dc8bec358f