### PR TITLE
Fix validator import in bot.js

### DIFF
--- a/ai-trading-bot/bot.js
+++ b/ai-trading-bot/bot.js
@@ -10,7 +10,8 @@ const risk = require('./risk');
 const fs = require('fs');
 const path = require('path');
 const { ethers, getAddress } = require('ethers');
-const validateTokens = require('./validator');
+// Import the token validation function from validator.js
+const { validateTokens } = require('./validator');
 const DEBUG_TOKENS = process.env.DEBUG_TOKENS === 'true';
 
 const tokensPath = path.join(__dirname, 'tokens.json');


### PR DESCRIPTION
## Summary
- fix validator function import to use named export

## Testing
- `node bot.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685dd0aaf8f483329850cdbecabddadb