### PR TITLE
Improve token scoring and group management

### DIFF
--- a/ai-trading-bot/strategy.js
+++ b/ai-trading-bot/strategy.js
@@ -10,7 +10,8 @@ function latestRsi(closing) {
 // AI-Enhanced Momentum Breakout strategy
 // prices - array of closing prices (oldest to newest)
 function analyze(symbol, prices) {
-  if (!Array.isArray(prices) || prices.length < 5 || prices.some(p => p == null)) {
+  // Require at least 10 candles for analysis to reduce noise
+  if (!Array.isArray(prices) || prices.length < 10 || prices.some(p => p == null)) {
     if (DEBUG_TOKENS) {
       console.log(`❌ Insufficient price history for ${symbol}`);
     }
@@ -119,15 +120,11 @@ function score(prices) {
     signals.push('Price above SMA5');
   }
 
-  if (sma5.length >= 2 && sma20.length >= 2) {
-    const prev = sma5[sma5.length - 2] <= sma20[sma20.length - 2];
-    const curr = sma5[sma5.length - 1] > sma20[sma20.length - 1];
-    if (prev && curr) {
-      signals.push('SMA5 crossover');
-    }
+  if (sma5.length && sma20.length && sma5[sma5.length - 1] > sma20[sma20.length - 1]) {
+    signals.push('SMA5 above SMA20');
   }
 
-  const score = Math.min(signals.length, 3);
+  const score = signals.length;
   return { score, signals };
 }
 


### PR DESCRIPTION
## Summary
- relax strategy scoring rules and require 10 candles
- simplify SMA logic and remove score cap
- show scores when logging GroupA promotions
- keep GroupB as top 25 tokens
- ensure GroupA always has 5 tokens
- skip price feeds for tokens without Chainlink feeds
- add safe fallback when all scores are 0

## Testing
- `node -e "require('./strategy.js');"` *(fails: Cannot find module 'technicalindicators')*

------
https://chatgpt.com/codex/tasks/task_e_685de1040f4c8332ab81eee7fb3d23d2