### PR TITLE
Improve scoring and token handling

### DIFF
--- a/ai-trading-bot/strategy.js
+++ b/ai-trading-bot/strategy.js
@@ -105,7 +105,8 @@ function score(prices) {
     return { score: 0, signals: [] };
   }
 
-  const rsiVals = RSI.calculate({ values: prices, period: 14 });
+  const rsiPeriod = Math.min(14, Math.max(5, prices.length - 1));
+  const rsiVals = RSI.calculate({ values: prices, period: rsiPeriod });
   const sma5 = SMA.calculate({ period: 5, values: prices });
   const sma20 = SMA.calculate({ period: 20, values: prices });
 


### PR DESCRIPTION
## Summary
- loosen scoring logic with adaptive RSI period
- load only 60 tokens and keep feed only for WETH
- fetch prices from DEX when no feed available and warn when <5 tokens score
- ensure buy orders allocate at least $10 worth of WETH and retry swaps

## Testing
- `node -c ai-trading-bot/bot.js`
- `node -c ai-trading-bot/trade.js`
- `node -c ai-trading-bot/strategy.js`
- `node ai-trading-bot/bot.js` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685df0f26d8c8332b12be38f0f86a5ea