### PR TITLE
Add DEBUG_PAIRS logging controls

### DIFF
--- a/ai-trading-bot/.env.example
+++ b/ai-trading-bot/.env.example
@@ -9,4 +9,5 @@ PAPER=true
 
 # Optional debugging
 DEBUG_TOKENS=false
+DEBUG_PAIRS=false
 DRY_RUN=false


### PR DESCRIPTION
## Summary
- allow configuring a DEBUG_PAIRS flag
- show pair/quote logs only when DEBUG_PAIRS=true
- track token pricing success counts in bot
- log priced tokens when DEBUG_PAIRS=true

## Testing
- `node -c src/bot.js && node -c src/trade.js`


------
https://chatgpt.com/codex/tasks/task_e_686374a1208c833298d1cd37750b2f34