### PR TITLE
Implement weighted signal scoring and ML dataset logging

### DIFF
--- a/ai-trading-bot/src/strategy.js
+++ b/ai-trading-bot/src/strategy.js
@@ -2,6 +2,56 @@ const { RSI, MACD, SMA } = require('technicalindicators');
 const DEBUG_TOKENS = process.env.DEBUG_TOKENS === 'true';
 const debug_pairs = process.env.DEBUG_PAIRS === 'true';
 
+// Calculate weighted score of technical signals for a set of closing prices
+function getTradeSignals(prices) {
+  if (!Array.isArray(prices) || prices.length < 26) {
+    return { rsi: null, macdHist: 0, smaAbove: false, momentum: 0, signalScore: 0 };
+  }
+
+  const rsiVals = RSI.calculate({ values: prices, period: 14 });
+  const smaVals = SMA.calculate({ period: 20, values: prices });
+  const macdVals = MACD.calculate({
+    values: prices,
+    fastPeriod: 12,
+    slowPeriod: 26,
+    signalPeriod: 9,
+    SimpleMAOscillator: false,
+    SimpleMASignal: false
+  });
+
+  const rsi = rsiVals[rsiVals.length - 1];
+  const prevRsi = rsiVals[rsiVals.length - 2];
+  const price = prices[prices.length - 1];
+  const prevPrice = prices[prices.length - 2];
+  const sma = smaVals[smaVals.length - 1];
+  const prevSma = smaVals[smaVals.length - 2];
+
+  const macdCurr = macdVals[macdVals.length - 1];
+  const macdPrev = macdVals[macdVals.length - 2];
+  const macdHist = (macdCurr.MACD - macdCurr.signal) || 0;
+  const prevHist = (macdPrev.MACD - macdPrev.signal) || 0;
+
+  const lookback = prices.length >= 6 ? prices[prices.length - 6] : prices[0];
+  const momentum = lookback ? (price - lookback) / lookback : 0;
+
+  let score = 0;
+  if (rsi < 30) score += 1;
+  if (prevRsi < 30 && rsi >= 30) score += 2;
+  const smaCross = prevPrice <= prevSma && price > sma;
+  if (smaCross) score += 2;
+  const macdUp = macdHist > prevHist || macdHist > 0;
+  if (macdUp) score += 2;
+  if (momentum > 0.5) score += 1;
+
+  return {
+    rsi,
+    macdHist: Number(macdHist.toFixed ? macdHist.toFixed(6) : macdHist),
+    smaAbove: price > sma,
+    momentum: Number(momentum.toFixed ? momentum.toFixed(6) : momentum),
+    signalScore: score
+  };
+}
+
 // Calculate the most recent RSI value from an array of closing prices
 function latestRsi(closing) {
   const values = RSI.calculate({ values: closing, period: 14 });
@@ -91,8 +141,8 @@ function analyze(symbol, prices) {
 }
 
 function shouldBuy(symbol, prices) {
-  const res = analyze(symbol, prices);
-  return res && res.action === 'BUY';
+  const signals = getTradeSignals(prices);
+  return signals.signalScore >= 3;
 }
 
 function shouldSell(symbol, prices) {
@@ -135,4 +185,4 @@ function score(prices) {
   return { score: signals.length, signals };
 }
 
-module.exports = { analyze, shouldBuy, shouldSell, latestRsi, score };
+module.exports = { analyze, shouldBuy, shouldSell, latestRsi, score, getTradeSignals };


### PR DESCRIPTION
## Summary
- add `getTradeSignals` for weighted scoring of RSI, SMA cross, MACD histogram and momentum
- trigger buys when `signalScore` >= 3
- log strategy features and decisions to `ml-dataset.jsonl`

## Testing
- `node -e "require('./ai-trading-bot/src/bot.js')"` *(fails: Cannot find module 'dotenv')*
- `node -e "require('./ai-trading-bot/src/strategy.js')"` *(fails: Cannot find module 'technicalindicators')*

------
https://chatgpt.com/codex/tasks/task_e_6863845dc3e483328d9f629d7d7ccb91