### PR TITLE
Add centralized error logger

### DIFF
--- a/ai-trading-bot/src/bot.js
+++ b/ai-trading-bot/src/bot.js
@@ -99,12 +99,7 @@ const logFile = path.join(__dirname, 'data', 'trade-log.json');
 const pnlFile = path.join(__dirname, 'data', 'pnl-log.jsonl');
 const mlFile = path.join(__dirname, 'data', 'ml-dataset.jsonl');
 
-function logError(err) {
-  console.error(err);
-}
-
-process.on('unhandledRejection', logError);
-process.on('uncaughtException', logError);
+const { logError } = require('./logger');
 
 function restorePortfolio() {
   let trades = [];

--- a/ai-trading-bot/src/logger.js
+++ b/ai-trading-bot/src/logger.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_DIR = path.join(process.cwd(), 'logs');
+const ERROR_LOG = path.join(LOG_DIR, 'errors.log');
+
+if (!fs.existsSync(LOG_DIR)) fs.mkdirSync(LOG_DIR, { recursive: true });
+if (!fs.existsSync(ERROR_LOG)) fs.writeFileSync(ERROR_LOG, '');
+
+function logError(context, error) {
+  const timestamp = new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angeles' });
+  const msg = `[${timestamp}] \u274c ${context}\n${error.stack || error.message || error}\n\n`;
+  try {
+    fs.appendFileSync(ERROR_LOG, msg);
+  } catch (e) {
+    console.error('Failed to write to error log:', e);
+  }
+}
+
+process.on('unhandledRejection', err => logError('Unhandled Rejection', err));
+process.on('uncaughtException', err => logError('Uncaught Exception', err));
+
+module.exports = { logError };

--- a/ai-trading-bot/src/trade.js
+++ b/ai-trading-bot/src/trade.js
@@ -2,6 +2,7 @@ const { ethers, getAddress } = require('ethers');
 const fs = require('fs');
 const path = require('path');
 const { SELL_DESTINATION } = require('./tokenManager');
+const { logError } = require('./logger');
 const QUOTER_V2_ADDRESS = '0x61fFE014bA17989E743c5F6cB21bF9697530B21e';
 const UNISWAP_QUOTER_ABI = [
   "function quoteExactInputSingle(address tokenIn, address tokenOut, uint24 fee, uint256 amountIn, uint160 sqrtPriceLimitX96) external view returns (uint256 amountOut)"
@@ -311,10 +312,6 @@ async function swapExactTokenForToken({ inputToken, outputToken, amountIn, slipp
     sqrtPriceLimitX96: 0
   };
   return router.exactInputSingle(params);
-}
-
-function logError(err) {
-  console.error(err);
 }
 
 const logPath = path.join(__dirname, 'data', 'trade-log.json');
@@ -722,6 +719,5 @@ module.exports = {
   getEthPrice,
   getTokenUsdPrice,
   TOKENS,
-  logError,
   refreshLocalTokenList
 };


### PR DESCRIPTION
## Summary
- implement logger module that records errors to `logs/errors.log`
- import and use logger in trading bot and trade module
- remove old error handlers and exports

## Testing
- `node --check ai-trading-bot/src/logger.js && node --check ai-trading-bot/src/bot.js && node --check ai-trading-bot/src/trade.js`

------
https://chatgpt.com/codex/tasks/task_e_6863943a922c83328e2e5a1e0e69dc34