### PR TITLE
Fix logger crash when error argument missing

### DIFF
--- a/ai-trading-bot/src/logger.js
+++ b/ai-trading-bot/src/logger.js
@@ -9,7 +9,19 @@ if (!fs.existsSync(ERROR_LOG)) fs.writeFileSync(ERROR_LOG, '');
 
 function logError(context, error) {
   const timestamp = new Date().toLocaleString('en-US', { timeZone: 'America/Los_Angeles' });
-  const msg = `[${timestamp}] \u274c ${context}\n${error.stack || error.message || error}\n\n`;
+
+  // Allow calling with a single argument (message or Error)
+  if (error === undefined) {
+    if (context instanceof Error) {
+      error = context;
+      context = 'Error';
+    } else {
+      error = null;
+    }
+  }
+
+  const details = error ? error.stack || error.message || String(error) : '';
+  const msg = `[${timestamp}] \u274c ${context}${details ? `\n${details}` : ''}\n\n`;
   try {
     fs.appendFileSync(ERROR_LOG, msg);
   } catch (e) {


### PR DESCRIPTION
## Summary
- Allow `logError` to be called with only a message or Error
- Prevent TypeError when `error` parameter is undefined

## Testing
- `node -e "const {logError}=require('./ai-trading-bot/src/logger'); logError('test message'); logError('with err', new Error('boom')); console.log('done');"`


------
https://chatgpt.com/codex/tasks/task_e_6897cebf75348332abeb550b9b81694a