### PR TITLE
Harden error logging and token list loading

### DIFF
--- a/ai-trading-bot/src/bot.js
+++ b/ai-trading-bot/src/bot.js
@@ -1,4 +1,7 @@
 require('dotenv').config();
+const { logError } = require('./logger');
+process.on('unhandledRejection', (e) => logError(e, { title: 'Unhandled Rejection' }));
+process.on('uncaughtException', (e) => logError(e, { title: 'Uncaught Exception' }));
 const FORCE_REFRESH = process.argv.includes('--force-refresh');
 if (FORCE_REFRESH) console.log('🔁 Forced refresh enabled');
 const strategy = require('./strategy');
@@ -99,7 +102,6 @@ const logFile = path.join(__dirname, 'data', 'trade-log.json');
 const pnlFile = path.join(__dirname, 'data', 'pnl-log.jsonl');
 const mlFile = path.join(__dirname, 'data', 'ml-dataset.jsonl');
 
-const { logError } = require('./logger');
 
 function restorePortfolio() {
   let trades = [];


### PR DESCRIPTION
## Summary
- replace file-based logger with console logger that normalizes any input and prints extra context
- robust token list loader that sanitizes JSON, handles HTTP errors and logs raw previews
- wire up global handlers for unhandled rejections and uncaught exceptions

## Testing
- `node --check src/logger.js`
- `node --check src/tokenManager.js`
- `node --check src/bot.js`


------
https://chatgpt.com/codex/tasks/task_e_6897d7482adc8332b960508fbb64ab66